### PR TITLE
Fix "Orem, OR" to be "Orem, UT"

### DIFF
--- a/fatal-police-shootings-data.csv
+++ b/fatal-police-shootings-data.csv
@@ -4178,7 +4178,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 4598,Eugene Horn,2019-03-28,shot,gun,43,M,,Phoenix,AZ,False,attack,Foot,False
 4607,Augustine Gutierrez,2019-03-28,shot,gun,42,M,H,San Antonio,TX,False,other,Car,False
 4606,Pierre J. Cher Frere,2019-03-30,shot,gun,25,M,B,Miami,FL,False,attack,,False
-4610,Andrew John Mason,2019-03-30,shot,unarmed,22,M,W,Watuaga County,NC,False,attack,Not fleeing,False
+4610,Andrew John Mason,2019-03-30,shot,unarmed,22,M,W,Watauga County,NC,False,attack,Not fleeing,False
 4669,Ondrae Levado Hutchinson,2019-03-30,shot and Tasered,gun,30,M,B,Durham,NC,False,attack,Foot,True
 4608,Stacy William Kenny,2019-03-31,shot,vehicle,33,F,W,Springfield,OR,True,other,Car,False
 4611,Juan Padilla,2019-03-31,shot,knife,24,M,H,Marana,AZ,False,attack,Not fleeing,False
@@ -4501,7 +4501,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 4924,Eric Toon,2019-08-01,shot,gun,36,M,W,Charleston,WV,False,attack,Other,False
 4925,David Willoughby,2019-08-01,shot,vehicle,54,M,,Jackson County,KY,False,attack,Car,False
 4926,Lenny Blaine Griffin,2019-08-01,shot,knife,48,M,W,Tampa,FL,True,other,Not fleeing,False
-4908,Delano Williams,2019-08-02,shot,gun,55,M,,Charlottte,NC,True,attack,Not fleeing,False
+4908,Delano Williams,2019-08-02,shot,gun,55,M,,Charlotte,NC,True,attack,Not fleeing,False
 4911,Mario Benjamin,2019-08-02,shot,gun,34,M,B,Minneapolis,MN,False,attack,Not fleeing,True
 4913,Deshon Downing,2019-08-02,shot,gun,45,M,B,Indianapolis,IN,False,attack,Not fleeing,False
 4912,De'Von Bailey,2019-08-03,shot,gun,19,M,B,Colorado Springs,CO,False,other,Foot,True

--- a/fatal-police-shootings-data.csv
+++ b/fatal-police-shootings-data.csv
@@ -3740,7 +3740,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 4098,Samuel Morris,2018-10-12,shot,knife,27,M,B,Fort Smith,AR,False,other,Not fleeing,False
 4099,Ashley Elisna Grammer,2018-10-12,shot,vehicle,26,F,O,Puna,HI,False,attack,Not fleeing,False
 4100,Kay Kenniker,2018-10-12,shot,gun,84,M,W,Chandler,AZ,True,attack,Not fleeing,False
-4096,Jacob E. Albrethsen,2018-10-12,shot and Tasered,knife,17,M,W,Orem,OR,False,other,Not fleeing,False
+4096,Jacob E. Albrethsen,2018-10-12,shot and Tasered,knife,17,M,W,Orem,UT,False,other,Not fleeing,False
 4091,Umberto Sanchez Ramoz,2018-10-14,shot,knife,17,M,H,Woodville,CA,True,attack,Not fleeing,False
 4093,Gregory Allen Tilly,2018-10-14,shot,gun,55,M,,Alamogordo,NM,False,other,Not fleeing,False
 4101,Eric Jamar Lupain Stromer,2018-10-14,shot,gun,22,M,B,Jeffersonville,OH,False,attack,Not fleeing,False


### PR DESCRIPTION
This appears to be a typo.  See, for example, this news article https://www.heraldextra.com/news/local/crime-and-courts/two-orem-officers-legally-justified-in-fatally-shooting-teenager-with/article_7beaea64-2a69-5566-a8c7-b31d0af7163e.html