### PR TITLE
Removed extra spaces from names and cities.

### DIFF
--- a/fatal-police-shootings-data.csv
+++ b/fatal-police-shootings-data.csv
@@ -21,7 +21,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 38,Jimmy Foreman,2015-01-09,shot,gun,71,M,W,England,AR,False,attack,Not fleeing,False,-91.966,34.542,True
 325,Andy Martinez,2015-01-09,shot,gun,33,M,H,El Paso,TX,False,attack,Not fleeing,False,-106.439,31.858,True
 42,Tommy Smith,2015-01-11,shot,gun,39,M,W,Arcola,IL,True,attack,Not fleeing,False,-88.304,39.692,True
-43,Brian  Barbosa,2015-01-11,shot,gun,23,M,H,South Gate,CA,False,attack,Not fleeing,False,-118.183,33.951,True
+43,Brian Barbosa,2015-01-11,shot,gun,23,M,H,South Gate,CA,False,attack,Not fleeing,False,-118.183,33.951,True
 45,Salvador Figueroa,2015-01-11,shot and Tasered,gun,29,M,H,North Las Vegas,NV,False,attack,Foot,False,-115.116,36.185,True
 46,John Edward O'Keefe,2015-01-13,shot,gun,34,M,W,Albuquerque,NM,False,attack,Foot,True,-106.586,35.095,True
 48,Richard McClendon,2015-01-13,shot,knife,43,M,W,Jourdanton,TX,True,other,Not fleeing,False,-98.542,28.912,True
@@ -90,7 +90,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 127,Markell Atkins,2015-02-04,shot,knife,36,M,B,Memphis,TN,False,other,Not fleeing,False,-89.932,35.164,True
 128,Paul Alfred Eugene Johnson,2015-02-05,shot,toy weapon,59,M,W,Chino,CA,False,other,Car,False,-117.65,33.953,True
 129,Herbert Hill,2015-02-06,shot,gun,25,M,B,Oklahoma City,OK,False,attack,Not fleeing,False,-97.515,35.404,True
-532,John  Sawyer,2015-02-07,shot,toy weapon,26,M,W,Calimesa,CA,False,attack,Not fleeing,False,-117.057,33.994,True
+532,John Sawyer,2015-02-07,shot,toy weapon,26,M,W,Calimesa,CA,False,attack,Not fleeing,False,-117.057,33.994,True
 554,James Allen,2015-02-07,shot,gun,74,M,B,Gastonia,NC,False,attack,Not fleeing,False,-81.227,35.266,True
 131,John Martin Whittaker,2015-02-08,shot,gun,33,M,W,Anchorage,AK,False,attack,Car,False,-149.859,61.208,True
 132,Sawyer Flache,2015-02-08,shot,gun,27,M,W,Austin,TX,False,attack,Not fleeing,False,-97.891,30.244,True
@@ -177,17 +177,17 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 206,Theodore Johnson,2015-03-10,shot,gun,64,M,B,Cleveland,OH,False,attack,Not fleeing,True,-81.641,41.45,True
 278,Jamie Croom,2015-03-10,shot,gun,31,M,B,Baton Rouge,LA,False,attack,Not fleeing,False,-91.169,30.536,True
 536,Christopher Mitchell,2015-03-10,shot,knife,23,M,W,Port Wentworth,GA,False,attack,Not fleeing,True,-81.184,32.165,True
-883,Edixon  Franco,2015-03-10,shot,sword,37,M,H,Ontario,CA,True,other,Car,False,-117.655,34.05,True
+883,Edixon Franco,2015-03-10,shot,sword,37,M,H,Ontario,CA,True,other,Car,False,-117.655,34.05,True
 248,Terry Garnett Jr.,2015-03-11,shot,,37,M,B,Elkton,MD,False,other,Not fleeing,False,-75.816,39.573,True
 277,James Greenwell,2015-03-11,shot,gun,31,M,W,Memphis,TN,True,attack,Not fleeing,False,-90.0,35.158,True
 279,Benito Osorio,2015-03-11,shot,gun,39,M,H,Santa Ana,CA,False,attack,Not fleeing,False,-117.868,33.743,True
 281,Ryan Dean Burgess,2015-03-11,shot,toy weapon,31,M,W,Kingman,AZ,True,attack,Not fleeing,False,-114.026,35.204,True
 307,Gilbert Fleury,2015-03-11,shot,gun,54,M,W,Bay Minette,AL,False,attack,Not fleeing,False,-87.891,30.862,True
-581,William Russell  Smith,2015-03-11,shot,gun,53,M,W,Hoover,AL,True,attack,Not fleeing,False,-86.849,33.417,True
+581,William Russell Smith,2015-03-11,shot,gun,53,M,W,Hoover,AL,True,attack,Not fleeing,False,-86.849,33.417,True
 796,Aaron Valdez,2015-03-11,shot,,25,M,H,Los Angeles,CA,False,other,Not fleeing,False,-118.22,33.939,True
 282,Bobby Gross,2015-03-12,shot,unarmed,35,M,B,Washington,DC,True,other,Not fleeing,False,-76.983,38.882,True
 207,James Richard Jimenez,2015-03-13,shot,gun,41,M,H,Napa,CA,False,other,Other,False,-122.274,38.306,True
-283,Fred  Liggett,2015-03-13,shot,gun,59,M,W,Kansas City,MO,False,attack,Not fleeing,False,-94.487,38.947,True
+283,Fred Liggett,2015-03-13,shot,gun,59,M,W,Kansas City,MO,False,attack,Not fleeing,False,-94.487,38.947,True
 289,Andrew Driver,2015-03-13,shot,knife,36,M,W,Fontana,CA,False,attack,Not fleeing,False,-117.43,34.078,True
 351,Antonio Perez,2015-03-13,shot,unarmed,32,M,H,Walnut Creek,CA,False,other,Foot,False,-118.229,33.971,True
 208,Clifton Reintzel,2015-03-14,shot,knife,53,M,W,Follansbee,WV,False,other,Not fleeing,False,-80.596,40.331,True
@@ -208,7 +208,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 229,Brandon Jones,2015-03-19,shot,unarmed,18,M,B,Cleveland,OH,False,attack,Not fleeing,False,-81.609,41.529,True
 230,Brandon Rapp,2015-03-19,shot,gun,31,M,W,Middleton,ID,False,attack,Not fleeing,True,-116.58,43.704,True
 265,Kendre Alston,2015-03-19,shot,gun,16,M,B,Jacksonville,FL,False,attack,Car,False,-81.68,30.379,True
-295,Jamison  Childress,2015-03-19,shot,unarmed,20,M,W,Sumas,WA,True,attack,Not fleeing,False,-122.273,49.0,True
+295,Jamison Childress,2015-03-19,shot,unarmed,20,M,W,Sumas,WA,True,attack,Not fleeing,False,-122.273,49.0,True
 306,Robert Burdge,2015-03-19,shot,gun,36,M,W,Bakersfield,CA,False,attack,Not fleeing,False,-119.336,35.355,True
 308,Richard White,2015-03-20,shot,machete,63,M,B,New Orleans,LA,True,attack,Not fleeing,False,-90.265,29.993,True
 310,Tyrel Vick,2015-03-20,shot,gun,34,M,W,Coal County,OK,False,attack,Not fleeing,False,-96.323,34.506,True
@@ -308,7 +308,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 409,Hector Morejon,2015-04-23,shot,unarmed,19,M,H,Long Beach,CA,False,other,Not fleeing,False,-118.174,33.781,True
 401,Karen Janks,2015-04-24,shot,,46,F,W,Windsor,CA,False,attack,Car,False,-122.792,38.375,True
 402,Mark Cecil Hawkins,2015-04-24,shot,gun,49,M,W,Eugene,OR,False,attack,Not fleeing,False,-122.997,44.914,True
-403,Gary Timmie  Collins,2015-04-24,shot,gun,63,M,W,Miami,OK,False,attack,Car,False,-94.887,36.897,True
+403,Gary Timmie Collins,2015-04-24,shot,gun,63,M,W,Miami,OK,False,attack,Car,False,-94.887,36.897,True
 412,Todd Jamal Dye,2015-04-24,shot,gun,20,M,B,Trinidad,CO,False,attack,Foot,True,-104.493,37.176,True
 408,Brandon Lawrence,2015-04-25,shot,machete,25,M,W,Victoria,TX,True,other,Not fleeing,True,-97.001,28.878,True
 411,David Felix,2015-04-25,shot,unarmed,24,M,B,New York,NY,True,attack,Foot,False,-73.982,40.725,True
@@ -316,7 +316,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 404,Billy Joe Patrick,2015-04-26,shot,unarmed,29,M,W,Bunch,OK,False,attack,Not fleeing,False,-94.772,35.745,True
 406,Albert Hanson,2015-04-26,shot,gun,76,M,W,Kings County,CA,False,attack,Not fleeing,False,-119.601,36.211,True
 407,Dean Genova,2015-04-26,shot,gun,45,M,W,Fountain Valley,CA,False,attack,Not fleeing,False,-117.956,33.696,True
-405,Terrance  Kellom,2015-04-27,shot,hammer,20,M,B,Detroit,MI,False,other,Not fleeing,False,-83.236,42.366,True
+405,Terrance Kellom,2015-04-27,shot,hammer,20,M,B,Detroit,MI,False,other,Not fleeing,False,-83.236,42.366,True
 413,David Parker,2015-04-28,shot,gun,58,M,W,Mansfield,OH,False,attack,Not fleeing,False,-82.516,40.739,True
 417,Jared Johnson,2015-04-28,shot,gun,21,M,B,New Orleans,LA,False,attack,Not fleeing,True,-89.966,30.019,True
 420,Joshua Green,2015-04-28,shot,gun,27,M,W,Marion,IL,True,attack,Not fleeing,False,-88.941,37.731,True
@@ -346,7 +346,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 443,David Schwalm,2015-05-08,shot,gun,58,M,W,Constantia,NY,True,attack,Not fleeing,False,-76.008,43.266,True
 451,Dedrick Marshall,2015-05-08,shot,gun,48,M,B,Harvey,LA,False,attack,Not fleeing,False,-90.072,29.86,True
 454,Sam Holmes,2015-05-08,shot,,31,M,B,Fridley,MN,False,attack,Car,False,-93.266,45.07,True
-453,Stephen  Cunningham,2015-05-10,shot,gun,47,M,W,Tacoma,WA,False,attack,Not fleeing,False,-122.489,47.229,True
+453,Stephen Cunningham,2015-05-10,shot,gun,47,M,W,Tacoma,WA,False,attack,Not fleeing,False,-122.489,47.229,True
 455,Lionel Lorenzo Young,2015-05-10,shot,,34,M,B,Landover,MD,False,other,Car,False,-76.875,38.902,True
 437,Kelvin Goldston,2015-05-11,shot,,30,M,B,Fort Worth,TX,False,attack,Car,False,-97.395,32.661,True
 444,Justin Way,2015-05-11,shot,knife,28,M,W,St. Augustine,FL,True,other,Not fleeing,False,-81.481,29.973,True
@@ -358,16 +358,16 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 460,Mark Farrar,2015-05-15,shot,gun,41,M,W,Rockford,IL,True,attack,Not fleeing,False,-89.069,42.25,True
 462,Matt Coates,2015-05-15,shot,toy weapon,42,M,W,Sacramento,CA,True,attack,Not fleeing,False,-121.434,38.552,True
 463,Ronell Wade,2015-05-16,shot,gun,45,M,B,Harvey,IL,False,attack,Foot,False,-87.634,41.603,True
-458,Dennis  Fiel,2015-05-17,shot,gun,34,M,W,San Diego,CA,True,attack,Foot,True,-117.154,32.802,True
+458,Dennis Fiel,2015-05-17,shot,gun,34,M,W,San Diego,CA,True,attack,Foot,True,-117.154,32.802,True
 459,Austin Goodner,2015-05-17,shot,gun,18,M,W,St. Petersburg,FL,True,attack,Not fleeing,False,-82.659,27.82,True
 461,Timothy Jones,2015-05-17,shot,sword,27,M,W,Ruidoso,NM,False,other,Not fleeing,False,-105.673,33.357,True
 457,Alfredo Rials-Torres,2015-05-19,shot,unarmed,54,M,H,Arlington,VA,False,attack,Not fleeing,False,-77.105,38.873,True
 464,Jonathan McIntosh,2015-05-19,shot,gun,35,M,W,Cabot,AR,False,attack,Not fleeing,False,-92.008,34.967,True
-465,David  Gaines,2015-05-19,shot,gun,17,M,W,Grand Junction,CO,False,attack,Other,False,-108.556,39.074,True
+465,David Gaines,2015-05-19,shot,gun,17,M,W,Grand Junction,CO,False,attack,Other,False,-108.556,39.074,True
 466,Anthony Gomez,2015-05-20,shot,gun,29,M,B,Lancaster,PA,False,attack,Not fleeing,False,-76.3,40.042,True
 468,Chrislon Talbott,2015-05-20,shot,gun,38,M,B,Owensboro,KY,False,attack,Not fleeing,False,-87.123,37.724,True
 489,Marcus Wheeler,2015-05-20,shot,gun,26,M,B,Omaha,NE,False,attack,Not fleeing,False,-95.957,41.324,True
-467,Jonathan  Colley,2015-05-20,shot and Tasered,knife,52,M,W,Green,OH,False,other,Not fleeing,False,-81.429,40.965,True
+467,Jonathan Colley,2015-05-20,shot and Tasered,knife,52,M,W,Green,OH,False,other,Not fleeing,False,-81.429,40.965,True
 486,Nikki Jo Burtsfield,2015-05-20,shot and Tasered,knife,39,F,W,Gillette,WY,False,other,Car,False,-105.45,44.302,True
 469,David Alejandro Gandara,2015-05-21,shot,gun,22,M,H,El Paso,TX,True,undetermined,Not fleeing,False,-106.423,31.904,True
 483,Javoris Washington,2015-05-21,shot,knife,29,M,B,Ft. Lauderdale,FL,False,attack,Not fleeing,False,-80.184,26.107,True
@@ -381,10 +381,10 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 475,Cassandra Bolin,2015-05-25,shot,gun,31,F,W,Austin,TX,True,attack,Not fleeing,False,-97.721,30.332,True
 476,Anthony Briggs,2015-05-25,shot,knife,36,M,B,Huntsville,AL,True,attack,Not fleeing,False,-86.564,34.614,True
 477,Dalton Branch,2015-05-26,shot,gun,51,M,B,Queens,NY,False,attack,Not fleeing,False,-73.889,40.657,True
-479,Jessie  Williams,2015-05-26,shot,undetermined,24,M,W,Bossier City,LA,False,attack,Not fleeing,False,-93.708,32.517,True
+479,Jessie Williams,2015-05-26,shot,undetermined,24,M,W,Bossier City,LA,False,attack,Not fleeing,False,-93.708,32.517,True
 530,Millard Tallant III,2015-05-26,shot,gun,62,M,W,Snohomish,WA,True,attack,Not fleeing,False,-122.014,47.838,True
 480,Scott McAllister,2015-05-27,shot,knife,39,M,W,Ideal Beach,NJ,False,attack,Not fleeing,False,-74.113,40.444,True
-481,Garrett  Sandeno,2015-05-27,shot,toy weapon,24,M,W,Edmond,OK,True,attack,Not fleeing,False,-97.455,35.634,True
+481,Garrett Sandeno,2015-05-27,shot,toy weapon,24,M,W,Edmond,OK,True,attack,Not fleeing,False,-97.455,35.634,True
 482,Harry Davis,2015-05-27,shot,knife,57,M,W,Rockville,GA,True,attack,Not fleeing,False,-83.206,33.344,True
 491,Feras Morad,2015-05-27,shot and Tasered,unarmed,20,M,O,Long Beach,CA,False,other,Not fleeing,False,-118.139,33.785,True
 492,Simon Hubble,2015-05-27,shot and Tasered,screwdriver,33,M,W,Alpine,CA,True,other,Not fleeing,False,-116.699,32.751,True
@@ -420,12 +420,12 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 524,Rene Garcia,2015-06-08,shot,knife,30,M,H,Anaheim,CA,True,other,Not fleeing,True,-117.922,33.847,True
 526,Richard Warolf,2015-06-08,shot,gun,69,M,W,Sun City,AZ,True,attack,Not fleeing,False,-112.257,33.631,True
 525,Jeremy Linhart,2015-06-09,shot,unarmed,30,M,W,Findlay,OH,False,attack,Not fleeing,False,-83.662,41.037,True
-535,Greg  Hartley,2015-06-09,shot,gun,45,M,W,Tomball,TX,False,attack,Car,False,-95.617,30.031,True
+535,Greg Hartley,2015-06-09,shot,gun,45,M,W,Tomball,TX,False,attack,Car,False,-95.617,30.031,True
 538,QuanDavier Hicks,2015-06-09,shot,gun,22,M,B,Cincinnati,OH,False,attack,Not fleeing,False,-84.546,39.164,True
 539,Ryan Bolinger,2015-06-09,shot,unarmed,28,M,W,Des Moines,IA,False,other,Car,False,-93.698,41.623,True
 540,Isiah Hampton,2015-06-10,shot,gun,19,M,B,Bronx,NY,False,attack,Not fleeing,False,-73.896,40.856,True
 541,Charles Ziegler,2015-06-11,shot,gun,40,M,B,Pompano Beach,FL,False,attack,Not fleeing,False,-80.105,26.276,True
-542,Raymond  Phillips,2015-06-11,shot,gun,86,M,,Columbia,TN,True,attack,Not fleeing,False,-86.943,35.633,True
+542,Raymond Phillips,2015-06-11,shot,gun,86,M,,Columbia,TN,True,attack,Not fleeing,False,-86.943,35.633,True
 543,Fritz Severe,2015-06-11,shot,undetermined,46,M,B,Miami,FL,False,other,Not fleeing,False,-80.2,25.787,True
 544,Mark Flores,2015-06-11,shot,gun,28,M,H,Bexar County,TX,True,attack,Not fleeing,False,-98.355,29.523,True
 545,Raymond Peralta-Lantigua,2015-06-11,shot,knife,22,M,H,Hackensack,NJ,True,other,Not fleeing,False,-74.04,40.907,True
@@ -446,7 +446,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 565,Louis Atencio,2015-06-19,shot,gun,50,M,H,Greeley,CO,False,attack,Not fleeing,False,-104.704,40.427,True
 582,Alfontish Cockerham,2015-06-20,shot,gun,23,M,B,Chicago,IL,False,attack,Foot,False,-87.573,41.766,True
 555,Adrian Simental,2015-06-21,shot,unarmed,24,M,H,Azusa,CA,True,other,Not fleeing,False,-117.9,34.129,True
-556,Charles  Marshall,2015-06-21,shot,cordless drill,49,M,W,Houston,TX,True,other,Not fleeing,False,-95.442,30.03,True
+556,Charles Marshall,2015-06-21,shot,cordless drill,49,M,W,Houston,TX,True,other,Not fleeing,False,-95.442,30.03,True
 566,James Monroe Barrett,2015-06-22,shot,gun,60,M,W,Ronda,NC,False,attack,Foot,False,-80.887,36.229,True
 570,Eduardo Reyes,2015-06-22,shot,gun,35,M,H,Citrus Heights,CA,False,attack,Not fleeing,False,-121.29,38.677,True
 573,Tyler Wicks,2015-06-22,shot,gun,29,M,W,Augusta,GA,True,attack,Not fleeing,False,-82.02,33.415,True
@@ -461,9 +461,9 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 579,Richard Matt,2015-06-26,shot,gun,49,M,W,Malone,NY,False,attack,Other,False,-74.285,44.743,True
 583,Joe Angel Cisneros,2015-06-26,shot,gun,28,M,H,San Antonio,TX,False,other,Foot,False,-98.64,29.418,True
 580,Joshua Crittenden,2015-06-27,shot,gun,35,M,W,Tahlequah,OK,False,attack,Not fleeing,True,-94.979,35.909,True
-577,Alan  Bellew,2015-06-28,shot,toy weapon,29,M,W,Portland,OR,False,attack,Not fleeing,False,-122.536,45.536,True
+577,Alan Bellew,2015-06-28,shot,toy weapon,29,M,W,Portland,OR,False,attack,Not fleeing,False,-122.536,45.536,True
 585,Richard LaPort,2015-06-29,shot,gun,51,M,W,Edinburg,NY,True,attack,Not fleeing,False,-74.069,43.208,True
-586,Clay Alan  Lickteig,2015-06-30,shot,gun,52,M,W,Franklin,NC,False,attack,Not fleeing,False,-83.388,35.194,True
+586,Clay Alan Lickteig,2015-06-30,shot,gun,52,M,W,Franklin,NC,False,attack,Not fleeing,False,-83.388,35.194,True
 587,Kevin Lamont Judson,2015-07-01,shot,,24,M,B,McMinnville,OR,False,attack,Foot,False,-123.168,45.23,True
 589,Kaleb Landon,2015-07-01,shot,gun,32,M,W,Josephine County,OR,False,attack,Car,False,-123.384,42.646,True
 588,Douglas Buckley,2015-07-02,shot,toy weapon,45,M,W,Brockton,MA,True,attack,Not fleeing,False,-71.014,42.053,True
@@ -531,7 +531,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 657,Darrius Stewart,2015-07-17,shot,unarmed,19,M,B,Memphis,TN,False,attack,Foot,False,-89.874,35.05,True
 660,Jose Roman Rodriguez,2015-07-17,shot,screwdriver,24,M,H,Brownsville,TX,False,other,Other,False,-97.472,25.897,True
 651,Albert Joseph Davis,2015-07-17,shot and Tasered,unarmed,23,M,B,Orlando,FL,False,attack,Foot,False,-81.334,28.522,True
-650,David  Wheat Jr.,2015-07-18,shot,knife,22,M,W,Fort Collins,CO,True,attack,Not fleeing,False,-105.1,40.565,True
+650,David Wheat Jr.,2015-07-18,shot,knife,22,M,W,Fort Collins,CO,True,attack,Not fleeing,False,-105.1,40.565,True
 652,Kevin Thomas Snyder,2015-07-18,shot,gun,46,M,W,Phoenix,AZ,False,attack,Not fleeing,False,-112.152,33.553,True
 654,Charles Edward Dewey,2015-07-18,shot,gun,65,M,W,Colby,KS,False,attack,Not fleeing,False,-101.04,39.398,True
 653,Samuel DuBose,2015-07-19,shot,unarmed,43,M,B,Mt. Auburn,OH,False,other,Car,True,-84.513,39.122,True
@@ -552,7 +552,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 675,Lee Aaron Gerston,2015-07-24,shot and Tasered,knife,30,M,W,Pinnacle,NC,False,other,Not fleeing,False,-80.433,36.329,True
 676,Christopher Olmstead,2015-07-25,shot,blunt object,60,M,W,New Orleans,LA,True,attack,Car,False,-90.017,29.956,True
 677,Roger Braswell,2015-07-25,shot,gun,50,M,W,Decatur,GA,True,attack,Not fleeing,False,-84.735,30.849,True
-678,Bryan Keith  Day,2015-07-25,shot,toy weapon,36,M,B,Las Vegas,NV,False,attack,Not fleeing,False,-115.106,36.159,True
+678,Bryan Keith Day,2015-07-25,shot,toy weapon,36,M,B,Las Vegas,NV,False,attack,Not fleeing,False,-115.106,36.159,True
 685,Earl Jackson,2015-07-25,shot,gun,59,M,B,Micanopy,FL,False,attack,Not fleeing,False,-82.28,29.505,True
 679,Khari Westly,2015-07-26,shot,gun,33,M,B,Shreveport,LA,False,attack,Not fleeing,False,-93.789,32.482,True
 680,Zachary Hammond,2015-07-26,shot,,19,M,W,Seneca,SC,False,other,Other,False,-82.974,34.693,True
@@ -567,8 +567,8 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 690,Philip Vallejo,2015-07-30,shot,gun,30,M,H,Fort Worth,TX,False,attack,Not fleeing,False,-97.331,32.754,True
 691,Oscar Lotari Romero,2015-07-30,shot and Tasered,metal stick,47,M,H,Whittier,CA,False,attack,Not fleeing,False,-118.055,33.972,True
 692,Rafael Molina,2015-07-31,shot,gun,33,M,H,Albuquerque,NM,False,attack,Not fleeing,True,-106.643,35.073,True
-693,Jeremy  Hatch,2015-07-31,shot,gun,34,M,W,Roswell,NM,False,attack,Not fleeing,False,-104.523,33.395,True
-694,David  Cook,2015-08-01,shot,gun,52,M,,Nitro,WV,False,attack,Not fleeing,False,-81.841,38.402,True
+693,Jeremy Hatch,2015-07-31,shot,gun,34,M,W,Roswell,NM,False,attack,Not fleeing,False,-104.523,33.395,True
+694,David Cook,2015-08-01,shot,gun,52,M,,Nitro,WV,False,attack,Not fleeing,False,-81.841,38.402,True
 696,Armando Serrano,2015-08-01,shot,gun,29,M,H,Tucson,AZ,False,attack,Not fleeing,False,-110.973,32.272,True
 695,Virgil Reynolds,2015-08-02,shot,,63,M,W,Houston,TX,True,other,Not fleeing,False,-95.557,29.689,True
 697,Antonio Clements,2015-08-03,shot,gun,49,M,B,Oakland,CA,False,attack,Not fleeing,False,-122.269,37.827,True
@@ -614,7 +614,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 750,Christopher Anderson,2015-08-14,shot and Tasered,box cutter,53,M,W,Bolton,CT,False,attack,Car,False,-72.447,41.79,True
 742,Allen Matthew Baker,2015-08-15,shot,gun,23,M,B,Sunnyvale,CA,False,attack,Not fleeing,False,-122.027,37.395,True
 743,Benjamin Peter Ashley,2015-08-15,shot,gun,34,M,B,Inyokern,CA,True,attack,Not fleeing,False,-117.87,35.702,True
-744,Jonathon  Pope,2015-08-15,shot,gun,30,M,W,Carson City,NV,False,attack,Not fleeing,False,-119.722,39.184,True
+744,Jonathon Pope,2015-08-15,shot,gun,30,M,W,Carson City,NV,False,attack,Not fleeing,False,-119.722,39.184,True
 741,John Unsworth,2015-08-15,shot and Tasered,unarmed,43,M,W,Hanover,IN,False,attack,Not fleeing,False,-70.877,42.064,True
 745,Matthew Castillo,2015-08-16,shot,gun,29,M,H,San Jose,CA,False,other,Not fleeing,False,-121.834,37.295,True
 746,Steven B. Norton,2015-08-16,shot,gun,47,M,W,Kerrville,TX,False,attack,Not fleeing,False,-99.122,30.051,True
@@ -660,7 +660,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 789,Roger Albrecht,2015-08-29,shot,knife,43,M,W,San Antonio,TX,False,other,Not fleeing,False,-98.616,29.554,True
 795,Rafael Cruz Jr,2015-08-29,shot,unarmed,29,M,H,Chicago,IL,False,undetermined,Car,False,-87.671,41.851,True
 790,Shawn Hall,2015-08-30,shot,gun,20,M,W,Cushing,OK,False,attack,Not fleeing,False,-96.768,35.976,True
-791,David M.  Leon,2015-08-30,shot,gun,40,M,H,Tucson,AZ,False,attack,Not fleeing,False,-110.96,32.147,True
+791,David M. Leon,2015-08-30,shot,gun,40,M,H,Tucson,AZ,False,attack,Not fleeing,False,-110.96,32.147,True
 792,William Rippley,2015-08-31,shot,knife,45,M,W,Loveland,CO,False,attack,Foot,False,-105.028,40.407,True
 794,Cedric Maurice Williams,2015-09-01,shot,guns and explosives,33,M,B,Bluefield,WV,False,attack,Foot,False,-81.222,37.269,True
 797,Charles Robert Shaw,2015-09-01,shot,gun,76,M,W,Twinsburg,OH,False,attack,Not fleeing,False,-81.445,41.338,True
@@ -688,7 +688,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 817,Tian Ma,2015-09-10,shot,knife,31,M,A,Potsdam,NY,False,attack,Not fleeing,False,-74.992,44.668,True
 818,Bruce Santino,2015-09-10,shot,knife,35,M,,Fontana,CA,True,other,Not fleeing,False,-117.44,34.07,True
 819,Brandon Foy,2015-09-10,shot,gun,29,M,B,Indianapolis,IN,False,attack,Not fleeing,False,-86.28,39.836,True
-820, Austin Wilburly  Reid,2015-09-10,shot,gun,32,M,W,Lodi,CA,False,attack,Foot,False,-121.272,38.134,True
+820,Austin Wilburly Reid,2015-09-10,shot,gun,32,M,W,Lodi,CA,False,attack,Foot,False,-121.272,38.134,True
 823,Eddie Tapia,2015-09-10,shot,gun,41,M,H,Downey,CA,False,attack,Car,False,-118.114,33.955,True
 824,Robert T. Edwards,2015-09-11,shot,gun,31,M,W,Chester,PA,False,attack,Not fleeing,False,-75.393,39.834,True
 831,Phillip Pfleghardt,2015-09-11,shot,gun,44,M,W,Broomfield,CO,False,attack,Car,False,-105.062,39.958,True
@@ -701,7 +701,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 829,David Todd Powell,2015-09-14,shot,unarmed,28,M,W,Barstow,CA,True,attack,Not fleeing,False,-117.019,34.884,True
 830,Tyrone Bass,2015-09-15,shot,railroad spikes,21,M,B,Chalmette,LA,False,attack,Not fleeing,False,-89.953,29.93,True
 832,Florencio Chaidez,2015-09-15,shot,gun,32,M,H,Panorama City,CA,False,attack,Not fleeing,True,-118.438,34.23,True
-833,Jorge  Suarez-Ruiz,2015-09-15,shot,gun,51,M,H,Miami,FL,True,undetermined,Car,False,-80.453,25.727,True
+833,Jorge Suarez-Ruiz,2015-09-15,shot,gun,51,M,H,Miami,FL,True,undetermined,Car,False,-80.453,25.727,True
 834,Carlos Wilhelm,2015-09-15,shot,gun,39,M,H,Los Angeles,CA,False,attack,Not fleeing,False,-118.267,34.132,True
 837,Bobby R. Anderson,2015-09-15,shot,gun,27,M,B,Alexandria,LA,False,other,Not fleeing,False,-92.445,31.268,True
 835,Rory Lynn Gunderman,2015-09-16,shot,gun,31,M,W,Lead,SD,True,attack,Foot,False,-103.802,44.305,True
@@ -742,7 +742,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 873,Alberto Hernandez,2015-09-28,shot,toy weapon,59,M,H,San Ysidro,CA,False,attack,Not fleeing,True,-117.066,32.562,True
 872,Junior Prosper,2015-09-28,shot and Tasered,unarmed,31,M,B,Miami,FL,False,attack,Foot,False,-92.419,45.347,True
 877,Patrick Stephen Lundstrom,2015-09-29,shot,blunt object,46,M,N,Rapid City,SD,False,attack,Not fleeing,False,-103.214,44.072,True
-880,Robert  Christen,2015-09-29,shot,unarmed,37,M,W,Mora,MN,False,attack,Not fleeing,False,-93.296,45.872,True
+880,Robert Christen,2015-09-29,shot,unarmed,37,M,W,Mora,MN,False,attack,Not fleeing,False,-93.296,45.872,True
 876,Brandon Lamar Johnson,2015-09-30,shot,gun,28,M,B,Beckley,WV,False,attack,Car,False,-81.214,37.826,True
 888,David M. Diaz,2015-10-02,shot,gun,28,M,H,Sierra Vista,AZ,False,attack,Car,False,-110.233,31.467,True
 890,Phyllis Ilene Jepsen,2015-10-02,shot,knife,55,F,W,Aloha,OR,True,other,Not fleeing,False,-122.862,45.493,True
@@ -751,7 +751,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 886,James Joseph Byrd,2015-10-04,shot,beer bottle,45,M,W,Van Nuys,CA,False,undetermined,Not fleeing,False,-118.466,34.187,True
 887,Eric Edgell,2015-10-04,shot,gun,27,M,W,Muscle Shoals,AL,True,attack,Foot,False,-87.62,34.789,True
 891,Jeffery McCallum,2015-10-04,shot,gun,31,M,B,Chicago,IL,False,attack,Not fleeing,False,-87.713,41.867,True
-893,James  Dunaway,2015-10-05,shot,gun,51,M,W,Hurst,TX,False,attack,Foot,False,-97.202,32.817,True
+893,James Dunaway,2015-10-05,shot,gun,51,M,W,Hurst,TX,False,attack,Foot,False,-97.202,32.817,True
 894,Rodney Jencsik,2015-10-05,shot,gun,49,M,W,Woodbridge,NJ,False,attack,Not fleeing,False,-74.269,40.573,True
 895,Omar Ali,2015-10-05,shot,unarmed,27,M,O,Akron,OH,False,other,Not fleeing,False,-81.436,41.042,True
 957,Charles A. Pettit,2015-10-05,shot,gun,18,M,B,Midwest City,OK,False,attack,Not fleeing,False,-97.413,35.45,True
@@ -781,7 +781,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 920,Michael J. Brennan,2015-10-15,shot,toy weapon,31,M,W,Parma,OH,False,attack,Car,False,-81.71,41.421,True
 921,Robert Burgess,2015-10-15,shot,gun,35,M,W,Kirkland,WA,False,attack,Foot,False,-122.187,47.707,True
 922,Herbert Benitez,2015-10-15,shot,gun,27,M,H,San Francisco,CA,False,attack,Not fleeing,False,-122.415,37.779,True
-923,Martin  Ryans Jr.,2015-10-15,shot,gun,20,M,B,Houston,TX,False,attack,Not fleeing,False,-95.465,29.849,True
+923,Martin Ryans Jr.,2015-10-15,shot,gun,20,M,B,Houston,TX,False,attack,Not fleeing,False,-95.465,29.849,True
 924,Johnny Angel Rangel,2015-10-16,shot,unarmed,27,M,H,Valinda,CA,False,attack,Not fleeing,False,-117.916,34.031,True
 926,Jason Foreman,2015-10-16,shot,gun,45,M,,Barrow County,GA,False,attack,Not fleeing,False,-83.659,34.033,True
 927,Ricky Javenta Ball,2015-10-16,shot,undetermined,33,M,B,Columbus,MS,False,undetermined,Foot,True,-88.41,33.511,True
@@ -791,7 +791,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 931,Corey Jones,2015-10-18,shot,gun,31,M,B,Palm Beach Gardens,FL,False,undetermined,Not fleeing,False,-80.082,26.758,True
 932,Krikor Ekizian,2015-10-18,shot,knife,28,M,W,Fresno,CA,True,attack,Not fleeing,False,-119.769,36.803,True
 934,Dion Lamont Ramirez,2015-10-19,shot,,53,M,B,Los Angeles,CA,False,attack,Not fleeing,False,-118.281,33.935,True
-935,Roger D.  Hall,2015-10-20,shot,toy weapon,30,M,W,Louisville,KY,False,attack,Not fleeing,False,-85.578,38.227,True
+935,Roger D. Hall,2015-10-20,shot,toy weapon,30,M,W,Louisville,KY,False,attack,Not fleeing,False,-85.578,38.227,True
 936,Lamontez Jones,2015-10-20,shot,toy weapon,39,M,B,San Diego,CA,False,attack,Not fleeing,False,-117.159,32.714,True
 937,Joel Lopes,2015-10-20,shot,gun,40,M,H,Truth or Consequences,NM,False,attack,Not fleeing,False,-107.166,33.251,True
 938,Darien Greenwood,2015-10-20,shot,knife,30,M,W,Mandeville,LA,False,attack,Not fleeing,False,-90.031,30.409,True
@@ -837,11 +837,11 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 978,John Allen,2015-11-04,shot,gun,57,M,B,Houston,TX,False,attack,Car,False,-95.356,29.733,True
 979,Faisal Mohammad,2015-11-04,shot,knife,18,M,O,Merced,CA,False,attack,Foot,False,-120.425,37.365,True
 981,Timothy Gene Smith,2015-11-04,shot,unarmed,47,M,W,Pacific Beach,CA,False,other,Foot,True,-117.239,32.797,True
-983,David  Romanoski,2015-11-05,shot,gun,48,M,W,Morgantown,WV,False,attack,Not fleeing,False,-79.941,39.634,True
+983,David Romanoski,2015-11-05,shot,gun,48,M,W,Morgantown,WV,False,attack,Not fleeing,False,-79.941,39.634,True
 984,James Bigley,2015-11-05,shot,gun,20,M,W,Hominy,OK,True,attack,Car,False,-96.431,36.409,True
 985,Jacob Hohman,2015-11-05,shot,hammer,30,M,W,Lakeshire,MO,False,attack,Not fleeing,False,-90.341,38.538,True
 987,Laura Lemieux,2015-11-05,shot,gun,36,F,W,Goose Creek,SC,True,attack,Not fleeing,False,-80.02,32.964,True
-986,Michael  Johnson,2015-11-06,shot,gun,51,M,W,Portland,OR,True,attack,Not fleeing,False,-122.698,45.53,True
+986,Michael Johnson,2015-11-06,shot,gun,51,M,W,Portland,OR,True,attack,Not fleeing,False,-122.698,45.53,True
 988,James Francis Smyth,2015-11-06,shot,,55,M,W,Las Vegas,NV,False,other,Car,False,-115.137,36.038,True
 992,Kim Lee Long,2015-11-06,shot,undetermined,48,M,W,Wadesboro,NC,False,undetermined,Not fleeing,False,-80.04,34.981,True
 989,Delvin Simmons,2015-11-09,shot,,20,M,B,Spartanburg,SC,False,attack,Car,False,-81.979,34.949,True
@@ -905,7 +905,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 1043,Tuan Hoang,2015-11-30,shot,,25,M,A,Aurora,CO,False,attack,Car,False,-104.776,39.704,True
 1044,Darius Smith,2015-11-30,shot,gun,18,M,B,Atlanta,GA,False,attack,Foot,False,-84.387,33.779,True
 1227,Fernando Sauceda,2015-11-30,shot,undetermined,31,M,H,Wink,TX,False,other,Not fleeing,False,-103.163,31.74,True
-1045,Joshua  Jozefowicz ,2015-12-01,shot,gun,23,M,W,Bangor,ME,False,attack,Foot,False,-68.817,44.789,True
+1045,Joshua Jozefowicz ,2015-12-01,shot,gun,23,M,W,Bangor,ME,False,attack,Foot,False,-68.817,44.789,True
 1047,John Anthony Gonzalez,2015-12-01,shot,gun,18,M,H,Norwalk,CA,False,attack,Not fleeing,False,-118.082,33.917,True
 1049,Phillip Munoz,2015-12-02,shot,gun,35,M,H,Denver,CO,False,attack,Car,False,-105.037,39.755,True
 1050,Tashfeen Malik,2015-12-02,shot,gun,27,F,O,San Bernardino,CA,False,attack,Car,False,-117.29,34.108,True
@@ -920,7 +920,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 1060,Michael L. Funk,2015-12-05,shot,gun,60,M,W,Neenah,WI,False,other,Not fleeing,False,-88.466,44.187,True
 1061,Sheilah Huck,2015-12-05,shot,gun,61,F,W,St. Louis,MO,True,attack,Not fleeing,False,-90.239,38.811,True
 1062,Juan Perez,2015-12-05,shot,gun,38,M,H,Indio,CA,False,attack,Not fleeing,False,-116.251,33.698,True
-1059,David  Winesett,2015-12-05,shot and Tasered,straight edge razor,51,M,W,Miami,FL,False,other,Not fleeing,True,-80.141,25.788,True
+1059,David Winesett,2015-12-05,shot and Tasered,straight edge razor,51,M,W,Miami,FL,False,other,Not fleeing,True,-80.141,25.788,True
 1063,Raymond Azevedo,2015-12-06,shot,gun,35,M,W,Seattle,WA,False,attack,Car,False,-122.332,47.606,True
 1064,Carlumandarlo Zaramo,2015-12-06,shot,gun,46,M,B,Richmond Heights,OH,True,attack,Not fleeing,False,-81.498,41.541,True
 1065,John Alan Britton,2015-12-06,shot,knife,48,M,W,Laramie,WY,True,other,Not fleeing,False,-105.752,41.322,True
@@ -940,14 +940,14 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 1082,Andrew Jospeh Todd,2015-12-12,shot,gun,20,M,W,East Stroudsburg,PA,True,attack,Not fleeing,False,-75.182,40.991,True
 1083,Roy Carreon,2015-12-12,shot,knife,49,M,H,San Bernardino,CA,False,attack,,False,-117.322,34.108,True
 1086,Efrain Villanueva,2015-12-12,shot,unknown weapon,,M,,Aurora,CO,False,attack,,False,-104.861,39.726,True
-1077,Shirley  Weis,2015-12-13,shot,gun,51,F,W,Arlington,TX,True,attack,Not fleeing,False,-97.101,32.728,True
+1077,Shirley Weis,2015-12-13,shot,gun,51,F,W,Arlington,TX,True,attack,Not fleeing,False,-97.101,32.728,True
 1080,Ryan McMillan,2015-12-13,shot,ax,21,M,W,Denton,TX,True,other,Not fleeing,False,-97.133,33.215,True
-1084,Nephi  Leiataua,2015-12-13,shot,knife,30,M,O,Thurston County,WA,False,attack,Not fleeing,False,-122.762,47.002,True
+1084,Nephi Leiataua,2015-12-13,shot,knife,30,M,O,Thurston County,WA,False,attack,Not fleeing,False,-122.762,47.002,True
 1089,Enrique Gonzalez,2015-12-13,shot,gun,32,M,H,Mountain View,CO,False,attack,Not fleeing,False,-105.051,39.777,True
 1085,Calvin McKinnis,2015-12-14,shot,gun,33,M,B,New Orleans,LA,False,attack,Not fleeing,True,-89.905,30.038,True
-1090,Michael  Thomason,2015-12-14,shot,undetermined,56,M,W,Humboldt,TN,False,undetermined,Not fleeing,False,-88.845,35.852,True
+1090,Michael Thomason,2015-12-14,shot,undetermined,56,M,W,Humboldt,TN,False,undetermined,Not fleeing,False,-88.845,35.852,True
 1091,Brenda Dean Kimberling,2015-12-14,shot,gun,48,F,W,Las Vegas,NV,True,attack,Not fleeing,False,-115.057,36.244,True
-1092,Mharloun Verdejo  Saycon,2015-12-14,shot,knife,39,M,A,Long Beach,CA,False,other,Not fleeing,False,-118.189,33.803,True
+1092,Mharloun Verdejo Saycon,2015-12-14,shot,knife,39,M,A,Long Beach,CA,False,other,Not fleeing,False,-118.189,33.803,True
 1093,Hector Alvarez,2015-12-14,shot,unarmed,19,M,H,Gilroy,CA,False,other,Not fleeing,True,-121.573,36.995,True
 1094,Roberto Sanchez,2015-12-14,shot,gun,45,M,H,Las Vegas,NV,False,attack,Not fleeing,False,-115.09,36.229,True
 1095,Mark Toney,2015-12-14,shot,gun,33,M,W,Mount Hope,WV,False,attack,Not fleeing,False,-81.159,37.895,True
@@ -961,7 +961,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 1102,Robert L. Martinez,2015-12-18,shot,toy weapon,58,M,H,Taos,NM,True,attack,Not fleeing,False,-105.573,36.407,True
 1105,Ruben Jose Herrera,2015-12-19,shot,undetermined,26,M,H,Los Angeles,CA,True,attack,Not fleeing,False,-118.307,33.843,True
 1106,Leroy Browning,2015-12-20,shot,gun,30,M,B,Palmdale,CA,False,attack,Not fleeing,False,-118.045,34.572,True
-1107,Mark  Ramirez,2015-12-20,shot,gun,31,M,H,Amarillo,TX,True,attack,Not fleeing,False,-101.855,35.207,True
+1107,Mark Ramirez,2015-12-20,shot,gun,31,M,H,Amarillo,TX,True,attack,Not fleeing,False,-101.855,35.207,True
 1108,Guadalupe Quiroz,2015-12-21,shot,gun,34,M,H,Hemet,CA,False,attack,Not fleeing,False,-116.971,33.724,True
 1109,Bobby Daniels,2015-12-21,shot,gun,48,M,B,Douglasville,GA,False,attack,Not fleeing,False,-84.707,33.755,True
 1110,Michael Noel,2015-12-21,shot,unarmed,,M,B,Breaux Bridge,LA,True,other,Not fleeing,False,-91.864,30.239,True
@@ -972,7 +972,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 1114,Charles Reynolds,2015-12-22,shot,gun,61,M,,Ludlow,KY,False,attack,Not fleeing,True,-84.546,39.095,True
 1115,Kenneth Stephens,2015-12-22,shot,gun,56,M,W,Burlington,VT,False,attack,Not fleeing,True,-73.214,44.483,True
 1116,Michael Hilber,2015-12-22,shot,undetermined,29,M,W,Brooksville,FL,False,undetermined,Car,False,-82.384,28.466,True
-1117,Jose  Rodriguez,2015-12-22,shot,gun,19,M,H,Albuquerque,NM,False,undetermined,Foot,True,-106.566,35.076,True
+1117,Jose Rodriguez,2015-12-22,shot,gun,19,M,H,Albuquerque,NM,False,undetermined,Foot,True,-106.566,35.076,True
 1118,Kevin Matthews,2015-12-23,shot,unarmed,35,M,B,Dearborn,MI,True,other,Not fleeing,False,-83.194,42.351,True
 1120,Schuylar Gunning,2015-12-24,shot,,36,M,W,Winnsboro,LA,False,other,Car,False,-91.722,32.166,True
 1122,Gregory Sanders,2015-12-24,shot,gun,54,M,,Pride,LA,True,attack,Not fleeing,False,-90.972,30.694,True
@@ -2102,7 +2102,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 2346,Kadeem Torres,2017-02-16,shot,gun,17,M,B,Brooklyn,NY,False,attack,Foot,False,-73.876,40.673,True
 2349,Joseph Tamayo,2017-02-16,shot,gun,48,M,H,San Antonio,TX,False,attack,Not fleeing,False,-98.532,29.366,True
 2350,Jimmy Briggs,2017-02-16,shot,gun,21,M,B,Gardena,CA,False,attack,Foot,False,-118.297,33.903,True
-2710,Jonathon  Daniel Simmons,2017-02-16,shot,gun,22,M,W,Douglas City,CA,False,other,Not fleeing,False,,,True
+2710,Jonathon Daniel Simmons,2017-02-16,shot,gun,22,M,W,Douglas City,CA,False,other,Not fleeing,False,,,True
 2359,Joshua Henry,2017-02-17,shot,unarmed,30,M,W,Grand Prarie,TX,True,attack,Not fleeing,True,-96.997,32.717,True
 2361,David English,2017-02-17,shot,knife,34,M,W,Tulsa,OK,True,attack,Not fleeing,False,-95.869,36.015,True
 2363,Jean R. Valescot,2017-02-17,shot,gun,35,M,B,Big Lake,AK,False,attack,Not fleeing,False,,,True
@@ -4780,7 +4780,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 5197,Chris Ervie,2019-11-13,shot,knife,,M,W,Mandarin,FL,True,undetermined,Not fleeing,True,-81.593,30.178,True
 5203,Omar Enrique Garcia,2019-11-13,shot,sword,37,M,H,Los Angeles,CA,False,other,Foot,False,-118.244,34.052,True
 5204,Kennith Waynon Hooker,2019-11-14,shot,screwdriver,52,M,W,Beaumont,TX,False,attack,Not fleeing,False,-87.179,30.502,True
-5212,Michael  A. Jolly,2019-11-14,shot,gun,35,M,W,Fox Crossing,WI,True,other,Not fleeing,False,-88.494,44.229,True
+5212,Michael A. Jolly,2019-11-14,shot,gun,35,M,W,Fox Crossing,WI,True,other,Not fleeing,False,-88.494,44.229,True
 5190,Treon McCoy,2019-11-15,shot,gun,33,M,B,Charlotte,NC,False,attack,Not fleeing,False,-80.842,35.225,True
 5192,,2019-11-15,shot,gun,,M,,Westborough,MA,False,other,Not fleeing,False,-71.588,42.289,True
 5193,Mark Sheppard,2019-11-15,shot,gun,27,M,B,Cleveland,OH,False,other,Foot,False,-81.584,41.459,True
@@ -5175,7 +5175,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 5721,William Patrick Floyd,2020-03-27,shot,gun,51,M,,Salem,OR,False,other,,False,-122.99,44.943,True
 5695,Thomas Owens,2020-03-28,shot,gun,49,M,,Gray,KY,False,attack,Not fleeing,False,-83.941,36.917,True
 5696,Shane Farwell,2020-03-28,shot,gun,46,M,W,Caldwell,ID,False,attack,Not fleeing,False,,,True
-5697,Jacob  Emry Mcilveen,2020-03-29,shot,gun,22,M,W,Phoenix,AZ,True,attack,Not fleeing,False,,,True
+5697,Jacob Emry Mcilveen,2020-03-29,shot,gun,22,M,W,Phoenix,AZ,True,attack,Not fleeing,False,,,True
 5698,Etonne Tanzymore,2020-03-30,shot,gun,38,M,B,Baltimore,MD,False,attack,Not fleeing,True,-76.587,39.288,True
 5699,Jessie Stringfield,2020-03-30,shot,gun,44,M,W,Louisville,KY,False,attack,Not fleeing,True,,,True
 5700,Anthony Eduardo Pacheco,2020-03-31,shot,sword,37,M,H,Pomona,CA,False,other,Not fleeing,False,-117.737,34.061,True
@@ -6126,7 +6126,6 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 6656,Dwight Brown,2021-03-03,shot,gun,41,M,B,Abbeville,LA,True,attack,,True,-92.124,29.965,True
 7573,Jonathan Levi Allen,2021-03-03,shot,gun,28,M,W,Selma,IN,False,attack,Car,False,,,True
 6672,Judson Albahm,2021-03-04,shot,toy weapon,17,M,W,Jamesville,NY,True,attack,Foot,False,-76.075,42.981,True
-7880,Judson Albahm,2021-03-04,shot,toy weapon,17,M,,Jamesville,NY,True,attack,Foot,True,-76.075,42.981,True
 6674,Andrew Teague,2021-03-05,shot,gun,43,M,B,Columbus,OH,False,attack,Car,False,-83.048,39.898,True
 6675,Justin Lynn,2021-03-05,shot,gun,44,M,W,Odessa,TX,False,attack,,False,-102.317,31.855,True
 6678,,2021-03-05,shot,gun,,M,,Gainesville,FL,False,attack,,False,-82.268,29.63,True
@@ -7072,7 +7071,7 @@ id,name,date,manner_of_death,armed,age,gender,race,city,state,signs_of_mental_il
 7648,Michael J. Trappett,2022-01-31,shot,knife,48,M,,Orofino,ID,True,other,Not fleeing,True,,,True
 7704,Joseph Wayne Butler,2022-01-31,shot,gun,40,M,W,Mesquite,TX,False,attack,Foot,False,,,True
 7706,Michael Haas,2022-01-31,shot,gun,37,M,,Mishawaka,IN,False,attack,Not fleeing,True,,,True
-7647,Dustin Davidson,2022-02-01,shot,gun,29,M,,Wichita  Falls,TX,False,attack,Not fleeing,False,,,True
+7647,Dustin Davidson,2022-02-01,shot,gun,29,M,,Wichita Falls,TX,False,attack,Not fleeing,False,,,True
 7705,Devin Morris,2022-02-01,shot,gun,31,M,,Albuquerque,NM,False,other,Foot,False,,,True
 8263,Jonathon Murillo-Nix,2022-02-01,shot,knife,23,M,H,Los Angeles,CA,False,other,,False,,,True
 7646,Amir Locke,2022-02-02,shot,gun,22,M,B,Minneapolis,MN,False,attack,Not fleeing,True,,,True


### PR DESCRIPTION
ID   43: The name Brian Barbosa has an extra space in between the names.
ID  532: The name John Sawyer has an extra space in between the names.
ID  405: The name Terrance Kellom has an extra space in between the names.
ID  283: The name Fred Liggett has an extra space in between the names.
ID  581: The name William Russel Smith has an extra space between Russell and Smith.
ID  883: The name Edixon Franco has an extra space between the names.
ID  295: The name Jamison Childress has an extra space between the names.
ID  403: The name Gary Timmie Collins has an extra space between Timmie and Collins.
ID  453: The name Stephen Cunningham has an extra space between the names.
ID  458: The name Dennis Fiel has an extra space between the names.
ID  465: The name David Gaines has an extra space between the names.
ID  467: The name Jonathan Colley has an extra space between the names.
ID  479: The name Jessie Williams has an extra space between the names.
ID  481: The name Garrett Sandeno has an extra space between the names.
ID  535: The name Greg Hartley and an extra space between the names.
ID  542: The name Raymond Phillips has an extra space between the names.
ID  556: The name Charles Marshall has an extra space between the names.
ID  577: The name Alan Bellew has an extra space between the names.
ID  586: The name Clay Alan Lickteig has an extra space between Alan and Lickteig.
ID  650: The name David Wheat Jr. has an extra space between David and Wheat.
ID  678: The name Bryan Keith Day has an extra space between Keith and Day.
ID  693: The name Jeremy Hatch has an extra space between the names.
ID  694: The name David Cook has an extra space between the names.
ID  744: The name Jonathon Pope has an extra space between the names.
ID  791: The name David M. Leon has an extra space between M. and Leon.
ID  820: The name Austin Wilburly Reid has an extra space before Austin and an extra space between Wilburly and Reid.
ID  833: The name Jorge Suarez-Ruiz has an extra space between Jorge and Suarez-Ruiz.
ID  880: The name Robert Christen has an extra space between the names.
ID  893: The name James Dunaway has an extra space between the names.
ID  923: The name Martin Ryans Jr. has an extra space between Martin and Ryans.
ID  935: The name Roger D. Hall has an extra space between D. and Hall.
ID  983: The name David Romanoski has an extra space between the names.
ID  986: The name Michael Johnson has an extra space between the names.
ID 1045: The name Joshua Jozefowicz has an extra space between the names and an extra space after the last name.
ID 1059: The name David Winesett has an extra space between the names.
ID 1077: The name Shirley Weis has an extra space between the names.
ID 1084: The name Nephi Leiataua has an extra space between the names.
ID 1090: The name Michael Thomason has an extra space between the names.
ID 1092: The name Mharloun Verdejo Saycon has an extra space between Verdejo and Saycon.
ID 1107: The name Mark Ramirez has an extra space between the names.
ID 1117: The name Jose Rodriguez has an extra space between the names.
ID 2710: The name Jonathon Daniel Simmons has an extra space between Jonathon and Daniel.
ID 5212: The name Michael A. Jolly has an extra space between Michael and A. .
ID 5697: The name Jacob Emry Mcilveen has an extra space between Jacob and Emry.
ID 7647: The city Wichita Falls has an extra space between Wichita and Falls.